### PR TITLE
Reply to incoming request in all cases

### DIFF
--- a/worker/analyzer.js
+++ b/worker/analyzer.js
@@ -128,6 +128,7 @@ function analyze(callback) {
           console.error('Error publishing fin event: ' + util.inspect(err));
           return callback(err);
         }
+        return callback();
       });
     }
 


### PR DESCRIPTION
If no error occurred, hapi was not replying to the incoming request causing the root span of the request to never terminate and thus never publish.